### PR TITLE
refactor(mugshots): update presenter headshots layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,6 @@ Even with the best intentions, there may be trouble and I might not be available
 
 ## :camera: Presenter Headshots 
 
-[![Chris Heilmann at EnterJS](/photos/thumb-chris-heilmann-enterjs-cropped.jpg)](/photos/chris-heilmann-enterjs-cropped.jpg) 
-[![Chris Heilmann on stage at EnterJS](/photos/thumb-chris-heilmann-enterjs-live-cropped.jpg)](/photos/chris-heilmann-enterjs-live-cropped.jpg)
-[![Chris Heilmann on Surface Book](/photos/thumb-chris-heilmann-on-surface-book.jpg)](/photos/chris-heilmann-on-surface-book.jpg)
 [![Chris Heilmann at Smashingconf](/photos/thumb-chris-heilmann-dotted-shirt-microphone.jpg)](/photos/chris-heilmann-dotted-shirt-microphone.jpg)
 [![Chris Heilmann at Internet Days](/photos/thumb-chris-heilmann-internetdagarna2016.jpg)](/photos/chris-heilmann-internetdagarna2016.jpg)
 [![Chris Heilmann Peeking](/photos/thumb-chris-heilmann-tie-peeking.jpg)](/photos/chris-heilmann-tie-peeking.jpg)
@@ -118,6 +115,9 @@ Even with the best intentions, there may be trouble and I might not be available
 [![Chris Heilmann at TEDx Thessaloniki](/photos/thumb-chris-heilmann-tedx-thumbs.jpg)](/photos/chris-heilmann-tedx-thumbs.jpg)
 [![Chris Heilmann Mozilla shirt](/photos/thumb-chris-heilmann-hasgeek-mozilla.jpg)](/photos/chris-heilmann-hasgeek-mozilla.jpg)
 [![Chris Heilmann Mozilla shirt](/photos/thumb-chris-heilmann-black-polo.jpg)](/photos/chris-heilmann-black-polo.jpg)
+[![Chris Heilmann on stage at EnterJS](/photos/thumb-chris-heilmann-enterjs-live-cropped.jpg)](/photos/chris-heilmann-enterjs-live-cropped.jpg)
+[![Chris Heilmann at EnterJS](/photos/thumb-chris-heilmann-enterjs-cropped.jpg)](/photos/chris-heilmann-enterjs-cropped.jpg) 
+[![Chris Heilmann on Surface Book](/photos/thumb-chris-heilmann-on-surface-book.jpg)](/photos/chris-heilmann-on-surface-book.jpg)
 
 ## :copyright: Photo licenses and information:
 

--- a/index.html
+++ b/index.html
@@ -48,10 +48,9 @@
             color: grey;
             padding-right: 5px;
         }
-        .photos li {
-            list-style: none;
-            margin: 0;
-            padding: 0;
+        .photos a {
+            display: inline-block;
+            vertical-align: top;
         }
         img {display: block; float:left;padding:5px;}
         h2 {clear: both;}
@@ -238,63 +237,41 @@
 
 <h2 id="-camera-presenter-headshots">📷  Presenter Headshots</h2>
 
-<ul class="photos">
-    <li>
-        <a href="photos/chris-heilmann-dotted-shirt-microphone.jpg">
-            <img src="photos/thumb-chris-heilmann-dotted-shirt-microphone.jpg" alt="Chris Heilmann at Smashingconf">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-internetdagarna2016.jpg">
-            <img src="photos/thumb-chris-heilmann-internetdagarna2016.jpg" alt="Chris Heilmann at Internet Days">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-tie-peeking.jpg">
-            <img src="photos/thumb-chris-heilmann-tie-peeking.jpg" alt="Chris Heilmann Peeking">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-great-wide-open.jpg">
-            <img src="photos/thumb-chris-heilmann-great-wide-open.jpg" alt="Chris Heilmann at Great Wide Open">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-tedx-open.jpg">
-            <img src="photos/thumb-chris-heilmann-tedx-open.jpg" alt="Chris Heilmann at TEDx Thessaloniki">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-tedx-thumbs.jpg">
-            <img src="photos/thumb-chris-heilmann-tedx-thumbs.jpg" alt="Chris Heilmann at TEDx Thessaloniki">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-hasgeek-mozilla.jpg">
-            <img src="photos/thumb-chris-heilmann-hasgeek-mozilla.jpg" alt="Chris Heilmann Mozilla shirt">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-black-polo.jpg">
-            <img src="photos/thumb-chris-heilmann-black-polo.jpg" alt="Chris Heilmann Mozilla shirt">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-enterjs-cropped.jpg">
-            <img src="photos/thumb-chris-heilmann-enterjs-cropped.jpg" alt="Chris Heilmann at EnterJS">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-enterjs-live-cropped.jpg">
-            <img src="photos/thumb-chris-heilmann-enterjs-live-cropped.jpg" alt="Chris Heilmann on stage at EnterJS">
-        </a>
-    </li>
-    <li>
-        <a href="photos/chris-heilmann-on-surface-book.jpg">
-            <img src="photos/thumb-chris-heilmann-on-surface-book.jpg" alt="Chris Heilmann on Surface Book">
-        </a>
-    </li>
-</ul>  
+<div class="photos">
+    <a href="photos/chris-heilmann-dotted-shirt-microphone.jpg">
+        <img src="photos/thumb-chris-heilmann-dotted-shirt-microphone.jpg" alt="Chris Heilmann at Smashingconf">
+    </a>
+    <a href="photos/chris-heilmann-internetdagarna2016.jpg">
+        <img src="photos/thumb-chris-heilmann-internetdagarna2016.jpg" alt="Chris Heilmann at Internet Days">
+    </a>
+    <a href="photos/chris-heilmann-tie-peeking.jpg">
+        <img src="photos/thumb-chris-heilmann-tie-peeking.jpg" alt="Chris Heilmann Peeking">
+    </a>
+    <a href="photos/chris-heilmann-great-wide-open.jpg">
+        <img src="photos/thumb-chris-heilmann-great-wide-open.jpg" alt="Chris Heilmann at Great Wide Open">
+    </a>
+    <a href="photos/chris-heilmann-tedx-open.jpg">
+        <img src="photos/thumb-chris-heilmann-tedx-open.jpg" alt="Chris Heilmann at TEDx Thessaloniki">
+    </a>
+    <a href="photos/chris-heilmann-tedx-thumbs.jpg">
+        <img src="photos/thumb-chris-heilmann-tedx-thumbs.jpg" alt="Chris Heilmann at TEDx Thessaloniki">
+    </a>
+    <a href="photos/chris-heilmann-hasgeek-mozilla.jpg">
+        <img src="photos/thumb-chris-heilmann-hasgeek-mozilla.jpg" alt="Chris Heilmann Mozilla shirt">
+    </a>
+    <a href="photos/chris-heilmann-black-polo.jpg">
+        <img src="photos/thumb-chris-heilmann-black-polo.jpg" alt="Chris Heilmann Mozilla shirt">
+    </a>
+    <a href="photos/chris-heilmann-enterjs-live-cropped.jpg">
+        <img src="photos/thumb-chris-heilmann-enterjs-live-cropped.jpg" alt="Chris Heilmann on stage at EnterJS">
+    </a>
+    <a href="photos/chris-heilmann-enterjs-cropped.jpg">
+        <img src="photos/thumb-chris-heilmann-enterjs-cropped.jpg" alt="Chris Heilmann at EnterJS">
+    </a>
+    <a href="photos/chris-heilmann-on-surface-book.jpg">
+        <img src="photos/thumb-chris-heilmann-on-surface-book.jpg" alt="Chris Heilmann on Surface Book">
+    </a>
+</div>  
 
 <h2 id="-copyright-photo-licenses-and-information-">&copy; Photo licenses and information:</h2>
 <ul>


### PR DESCRIPTION
- remove `<ul/li>` in favor of `<div>`
- apply `display:inline-block` on anchors
- vertically align anchors to avoid user-agent defaults
- reflected the same image ordering in the markdown file as well
- change order of enterjs live and ded images for better height-to-width grouping
- tortured a kitten by tickling with a peacock feather while at it